### PR TITLE
Correct win

### DIFF
--- a/Circum.gmx/objects/o_player.object.gmx
+++ b/Circum.gmx/objects/o_player.object.gmx
@@ -75,29 +75,6 @@ ricochet_reward = 0;    // Records the ricochet reward (for the current version 
         <arguments>
           <argument>
             <kind>1</kind>
-            <string>/// Update
-
-player_update_clean(o_player, o_orb);
-</string>
-          </argument>
-        </arguments>
-      </action>
-      <action>
-        <libid>1</libid>
-        <id>603</id>
-        <kind>7</kind>
-        <userelative>0</userelative>
-        <isquestion>0</isquestion>
-        <useapplyto>-1</useapplyto>
-        <exetype>2</exetype>
-        <functionname></functionname>
-        <codestring></codestring>
-        <whoName>self</whoName>
-        <relative>0</relative>
-        <isnot>0</isnot>
-        <arguments>
-          <argument>
-            <kind>1</kind>
             <string>/// Win
 
 //if there isn't already a winner, check if something changed
@@ -119,6 +96,29 @@ if (global.winner == self.id &amp;&amp; radius &lt; room_width) {
     radius += 40;
     depth = -999;
 }
+</string>
+          </argument>
+        </arguments>
+      </action>
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
+            <string>/// Update
+
+player_update_clean(o_player, o_orb);
 </string>
           </argument>
         </arguments>

--- a/Circum.gmx/objects/o_player.object.gmx
+++ b/Circum.gmx/objects/o_player.object.gmx
@@ -30,7 +30,7 @@ color = c_white;
 action_key = vk_shift;
 
 trail_length = 30;          // in the anticipation of a longer trail under a certain condition
-
+draw_radius = 5;
 radius = 5;
 num_orb_captured = 0;
 launch_speed = 20;
@@ -92,8 +92,8 @@ if (global.winner &lt; 0) {
 }
 
 // If you won, consume the entire screen
-if (global.winner == self.id &amp;&amp; radius &lt; room_width) {
-    radius += 40;
+if (global.winner == self.id &amp;&amp; draw_radius &lt; room_width) {
+    draw_radius += 40;
     depth = -999;
 }
 </string>
@@ -144,7 +144,7 @@ player_update_clean(o_player, o_orb);
             <string>draw_set_circle_precision(64);
 draw_set_colour(color);
 draw_trail(trail_length, radius * 2, color, -1, true, 1);
-draw_circle(x, y, radius, false);
+draw_circle(x, y, draw_radius, false);
 
 draw_set_halign(fa_center);
 if (ricochet_reward == THEFT) {

--- a/Circum.gmx/scripts/player_update_clean.gml
+++ b/Circum.gmx/scripts/player_update_clean.gml
@@ -81,13 +81,20 @@ else {
             
             switch (orb.type) {
                 case VOID_ORB:
-                    // TODO: for every orb the player once owned, reset it
+                    // for every orb the player once owned, reset it
+                    with (o_orb) {
+                        if (capturer == other.id) { captured = false; capturer = -1; }
+                    }
+                    
                     instance_destroy();  // player dies
                     break;
                 case MASTER_ORB:
+                    // player wins iff the master orb is unguarded
                     if (!orb.guarded || orb.guarder == id) {
-                        num_orb_captured = instance_number(orb_obj);  // player wins
+                        //set to max
+                        num_orb_captured = instance_number(orb_obj);  
                     }
+                    
                     break;
                 case DEAD_ORB:
                     ricochet_streak++;

--- a/Circum.gmx/scripts/player_update_clean.gml
+++ b/Circum.gmx/scripts/player_update_clean.gml
@@ -82,8 +82,16 @@ else {
             switch (orb.type) {
                 case VOID_ORB:
                     // for every orb the player once owned, reset it
-                    with (o_orb) {
-                        if (capturer == other.id) { captured = false; capturer = -1; }
+                    with (orb_obj) {
+                        if (capturer == other.id) {
+                            captured = false;
+                            capturer = -1;
+                            color = c_gray;
+                        }
+                        if (guarder == other.id) {
+                            guarded = false;
+                            guarder = -1;
+                        }
                     }
                     
                     instance_destroy();  // player dies


### PR DESCRIPTION
- Hitting the void orb correctly changes global.winner (before, win-checking happened after update so winner was set to the dead player!)
- Winning expands the draw_radius, not the (collision-detecting) radius. This way, if you hit the master orb, you won't hit anything else when you "fill the screen".
- Reset status of captured/guarded orbs upon loss
